### PR TITLE
権限周りの設定

### DIFF
--- a/src/instant.perms.ts
+++ b/src/instant.perms.ts
@@ -10,7 +10,20 @@ const rules = {
       update: "isOwner",
       delete: "isOwner",
     },
-    bind: ["isOwner", "auth.id != null && auth.id == data.user.id"],
+    bind: ["isOwner", "auth.id !== null && auth.id === data.user.id"],
+  },
+  articles: {
+    allow: {
+      view: "true",
+      create: "isOwner",
+      update: "isOwner",
+      delete: "isOwner",
+    },
+    fields: {
+      draftContent: "isOwner",
+      status: "isOwner",
+    },
+    bind: ["isOwner", "auth.id !== null && auth.id === data.user.id"],
   },
 } satisfies InstantRules;
 

--- a/src/instant.perms.ts
+++ b/src/instant.perms.ts
@@ -20,6 +20,7 @@ const rules = {
       delete: "isOwner",
     },
     fields: {
+      draftTitle: "isOwner",
       draftContent: "isOwner",
       status: "isOwner",
     },

--- a/src/instant.schema.ts
+++ b/src/instant.schema.ts
@@ -14,10 +14,11 @@ const _schema = i.schema({
       createdAt: i.date(),
       updatedAt: i.date(),
     }),
-    posts: i.entity({
+    articles: i.entity({
       slug: i.string().unique().indexed(),
       title: i.string().indexed(),
-      content: i.string(),
+      publishedContent: i.string(),
+      draftContent: i.string(),
       status: i.string().indexed(),
       publishedAt: i.date().optional(),
       createdAt: i.date(),
@@ -38,9 +39,9 @@ const _schema = i.schema({
         label: "profile",
       },
     },
-    authorPosts: {
+    authorArticles: {
       forward: {
-        on: "posts",
+        on: "articless",
         has: "one",
         label: "author",
         onDelete: "cascade",
@@ -48,7 +49,7 @@ const _schema = i.schema({
       reverse: {
         on: "profiles",
         has: "many",
-        label: "posts",
+        label: "articles",
       },
     },
   },

--- a/src/instant.schema.ts
+++ b/src/instant.schema.ts
@@ -42,7 +42,7 @@ const _schema = i.schema({
     },
     authorArticles: {
       forward: {
-        on: "articless",
+        on: "articles",
         has: "one",
         label: "author",
         onDelete: "cascade",

--- a/src/instant.schema.ts
+++ b/src/instant.schema.ts
@@ -16,8 +16,9 @@ const _schema = i.schema({
     }),
     articles: i.entity({
       slug: i.string().unique().indexed(),
+      draftTitle: i.string().indexed(),
       title: i.string().indexed(),
-      publishedContent: i.string(),
+      content: i.string(),
       draftContent: i.string(),
       status: i.string().indexed(),
       publishedAt: i.date().optional(),


### PR DESCRIPTION
- ブログ記事の閲覧・編集の設定
  - 公開前の記事のタイトルと本文はその記事の作成者のみが見れるようにする
  - ブログ記事の編集権限はその記事の作成者のみが持つ